### PR TITLE
feat: scaffold BuildWise dashboard UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# BuildWise-AI
-AI-powered property analysis and construction management tool. Instantly estimates renovation costs, predicts resale/rental value, creates project schedules, and automates vendor communication for real estate investors and contractors.
+# BeamLot
+BeamLot is a premium AI tool for property investors, contractors, and flippers. Instantly estimates renovation costs, predicts resale/rental value, creates project schedules, and automates vendor communication.

--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  await new Promise(r => setTimeout(r, 500))
+  return NextResponse.json({
+    cost: '$10,000',
+    schedule: '30 days',
+    arv: '$150,000',
+    risks: 'Market shift'
+  })
+}

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+
+export async function POST(request: Request) {
+  const { priceId } = await request.json()
+  // Placeholder: In production, create a Stripe checkout session with the priceId
+  const url = `https://example.com/checkout?price=${priceId}`
+  return NextResponse.json({ url })
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useState } from 'react'
+import Sidebar from '../../components/Sidebar'
+import Topbar from '../../components/Topbar'
+import ProjectCard from '../../components/ProjectCard'
+import AnalyzeForm from '../../components/AnalyzeForm'
+import ResultsView from '../../components/ResultsView'
+import Timeline from '../../components/Timeline'
+import VendorEmailDraft from '../../components/VendorEmailDraft'
+import SignInModal from '../../components/SignInModal'
+import Toast from '../../components/Toast'
+
+const projects = [
+  { name: '123 Main St', address: '123 Main St', status: 'Planning', updatedAt: '2d ago' },
+  { name: '456 Oak Ave', address: '456 Oak Ave', status: 'In Progress', updatedAt: '1d ago' }
+]
+
+export default function Dashboard() {
+  const [results, setResults] = useState<any | null>(null)
+  const [toast, setToast] = useState('')
+  const [showModal, setShowModal] = useState(true)
+
+  return (
+    <div className="flex min-h-screen">
+      <Sidebar />
+      <div className="flex flex-1 flex-col">
+        <Topbar />
+        <main className="flex flex-col gap-4 p-4">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            {projects.map(p => (
+              <ProjectCard key={p.name} {...p} />
+            ))}
+          </div>
+          <AnalyzeForm onResults={data => { setResults(data); setToast('Analysis complete') }} />
+          {results ? <ResultsView data={results} /> : null}
+          <Timeline />
+          <VendorEmailDraft />
+        </main>
+      </div>
+      {toast && <Toast message={toast} onDone={() => setToast('')} />}
+      {showModal && <SignInModal onClose={() => setShowModal(false)} />}
+    </div>
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-blue-900 text-white;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import './globals.css'
 import type { ReactNode } from 'react'
 
-export const metadata = { title: 'BuildWise AI' }
+export const metadata = { title: 'BeamLot' }
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,14 @@
+import './globals.css'
+import type { ReactNode } from 'react'
+
+export const metadata = { title: 'BuildWise AI' }
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen flex flex-col">
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,7 +15,7 @@ export default function Landing() {
         <div className="rounded-2xl bg-white p-6 text-blue-900 shadow">Vendor outreach</div>
       </section>
       <section className="rounded-2xl bg-white p-6 text-blue-900 shadow">
-        <h2 className="text-2xl font-bold">Just $20/mo after a free trial</h2>
+        <h2 className="text-2xl font-bold">Just $79/mo or $790/yr</h2>
         <Link href="/pricing" className="mt-2 inline-block rounded-xl bg-blue-900 px-4 py-2 text-white">
           See pricing
         </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link'
+
+export default function Landing() {
+  return (
+    <main className="flex flex-col items-center justify-center gap-12 p-8 text-center">
+      <section className="mt-24">
+        <h1 className="text-4xl font-bold">Smarter property insights in minutes</h1>
+        <Link href="/dashboard" className="mt-6 inline-block rounded-xl bg-gold-500 px-6 py-3 text-blue-900 font-semibold">
+          Start free
+        </Link>
+      </section>
+      <section className="grid max-w-4xl grid-cols-1 gap-4 md:grid-cols-3">
+        <div className="rounded-2xl bg-white p-6 text-blue-900 shadow">Fast cost breakdowns</div>
+        <div className="rounded-2xl bg-white p-6 text-blue-900 shadow">Simple timelines</div>
+        <div className="rounded-2xl bg-white p-6 text-blue-900 shadow">Vendor outreach</div>
+      </section>
+      <section className="rounded-2xl bg-white p-6 text-blue-900 shadow">
+        <h2 className="text-2xl font-bold">Just $20/mo after a free trial</h2>
+        <Link href="/pricing" className="mt-2 inline-block rounded-xl bg-blue-900 px-4 py-2 text-white">
+          See pricing
+        </Link>
+      </section>
+    </main>
+  )
+}

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,16 +1,59 @@
+import { useState } from 'react'
+
+const PRICES = {
+  monthly: { amount: 79, stripeId: process.env.NEXT_PUBLIC_STRIPE_PRICE_MONTHLY || 'price_79_monthly' },
+  annual: { amount: 790, stripeId: process.env.NEXT_PUBLIC_STRIPE_PRICE_ANNUAL || 'price_790_annual' },
+}
+
 export default function Pricing() {
+  const [plan, setPlan] = useState<'monthly' | 'annual'>('monthly')
+
+  const handleSubscribe = async () => {
+    const res = await fetch('/api/checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ priceId: PRICES[plan].stripeId }),
+    })
+    const data = await res.json()
+    window.location.href = data.url
+  }
+
+  const isAnnual = plan === 'annual'
+
   return (
     <main className="flex flex-col items-center p-8 text-center">
-      <h1 className="mb-6 text-4xl font-bold">Simple pricing</h1>
+      <h1 className="mb-4 text-4xl font-bold">BeamLot Pricing</h1>
+      <p className="mb-8 max-w-xl text-white">
+        BeamLot is the premium AI tool for property investors, contractors, and flippers.
+      </p>
+      <div className="mb-6 flex rounded-xl overflow-hidden">
+        <button
+          onClick={() => setPlan('monthly')}
+          className={`px-4 py-2 ${plan === 'monthly' ? 'bg-gold-500 text-blue-900' : 'bg-blue-900 text-white'}`}
+        >
+          Monthly
+        </button>
+        <button
+          onClick={() => setPlan('annual')}
+          className={`px-4 py-2 ${plan === 'annual' ? 'bg-gold-500 text-blue-900' : 'bg-blue-900 text-white'}`}
+        >
+          Annual
+        </button>
+      </div>
       <div className="rounded-2xl bg-white p-8 text-blue-900 shadow">
-        <p className="text-6xl font-bold mb-4">$20</p>
-        <p className="mb-6">per month</p>
+        <p className="mb-4 text-6xl font-bold">${isAnnual ? '790' : '79'}</p>
+        <p className="mb-6">{isAnnual ? 'per year (2 months free)' : 'per month'}</p>
         <ul className="mb-6 space-y-2 text-left">
           <li>Unlimited projects</li>
           <li>AI cost & ARV analysis</li>
           <li>Email drafts to vendors</li>
         </ul>
-        <button className="rounded-xl bg-gold-500 px-6 py-3 text-blue-900 font-semibold">Subscribe</button>
+        <button
+          onClick={handleSubscribe}
+          className="rounded-xl bg-gold-500 px-6 py-3 text-blue-900 font-semibold"
+        >
+          Subscribe
+        </button>
       </div>
     </main>
   )

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,0 +1,17 @@
+export default function Pricing() {
+  return (
+    <main className="flex flex-col items-center p-8 text-center">
+      <h1 className="mb-6 text-4xl font-bold">Simple pricing</h1>
+      <div className="rounded-2xl bg-white p-8 text-blue-900 shadow">
+        <p className="text-6xl font-bold mb-4">$20</p>
+        <p className="mb-6">per month</p>
+        <ul className="mb-6 space-y-2 text-left">
+          <li>Unlimited projects</li>
+          <li>AI cost & ARV analysis</li>
+          <li>Email drafts to vendors</li>
+        </ul>
+        <button className="rounded-xl bg-gold-500 px-6 py-3 text-blue-900 font-semibold">Subscribe</button>
+      </div>
+    </main>
+  )
+}

--- a/components/AnalyzeForm.tsx
+++ b/components/AnalyzeForm.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+interface Props {
+  onResults: (data: any) => void
+}
+
+export default function AnalyzeForm({ onResults }: Props) {
+  const [address, setAddress] = useState('')
+  const [scope, setScope] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    const saved = localStorage.getItem('analyzeForm')
+    if (saved) {
+      const obj = JSON.parse(saved)
+      setAddress(obj.address)
+      setScope(obj.scope)
+    }
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem('analyzeForm', JSON.stringify({ address, scope }))
+  }, [address, scope])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!address) {
+      setError('Address required')
+      return
+    }
+    setError('')
+    setLoading(true)
+    const res = await fetch('/api/analyze')
+    const json = await res.json()
+    setLoading(false)
+    onResults(json)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 rounded-2xl bg-white p-4 text-blue-900 shadow">
+      <input
+        value={address}
+        onChange={e => setAddress(e.target.value)}
+        placeholder="Address"
+        className="w-full rounded border p-2"
+      />
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      <textarea
+        value={scope}
+        onChange={e => setScope(e.target.value)}
+        placeholder="Scope"
+        className="w-full rounded border p-2"
+      />
+      <button disabled={loading} className="rounded-xl bg-gold-500 px-4 py-2 font-semibold disabled:opacity-50">
+        {loading ? 'Analyzing...' : 'Analyze'}
+      </button>
+    </form>
+  )
+}

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -1,0 +1,17 @@
+interface Props {
+  name: string
+  address: string
+  status: string
+  updatedAt: string
+}
+
+export default function ProjectCard({ name, address, status, updatedAt }: Props) {
+  return (
+    <div className="rounded-2xl bg-white p-4 text-blue-900 shadow">
+      <h3 className="text-xl font-bold">{name}</h3>
+      <p className="text-sm">{address}</p>
+      <p className="mt-2 text-sm">Status: {status}</p>
+      <p className="text-xs">Updated {updatedAt}</p>
+    </div>
+  )
+}

--- a/components/ResultsView.tsx
+++ b/components/ResultsView.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useState } from 'react'
+
+interface Props {
+  data: any
+}
+
+const tabs = ['Cost', 'Schedule', 'ARV', 'Risks'] as const
+
+type Tab = typeof tabs[number]
+
+export default function ResultsView({ data }: Props) {
+  const [tab, setTab] = useState<Tab>('Cost')
+  const content = data[tab.toLowerCase()] || 'N/A'
+  return (
+    <div className="rounded-2xl bg-white p-4 text-blue-900 shadow">
+      <div className="mb-4 flex gap-2">
+        {tabs.map(t => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`rounded px-3 py-1 ${tab === t ? 'bg-gold-500 text-blue-900' : 'bg-blue-900 text-white'}`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      <p className="mb-4 whitespace-pre-wrap">{content}</p>
+      <button
+        onClick={() => navigator.clipboard.writeText(content)}
+        className="rounded bg-blue-900 px-3 py-1 text-white"
+      >
+        Copy
+      </button>
+    </div>
+  )
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+
+const items = ['Projects', 'Analyze', 'Vendors', 'Billing', 'Settings']
+
+export default function Sidebar() {
+  const [open, setOpen] = useState(false)
+  return (
+    <nav className={`bg-blue-900 p-4 text-white ${open ? 'w-48' : 'w-12'} md:w-48`}>
+      <button
+        onClick={() => setOpen(o => !o)}
+        className="mb-4 md:hidden"
+      >
+        ☰
+      </button>
+      <ul className={`${open ? 'block' : 'hidden'} md:block space-y-2`}>
+        {items.map(i => (
+          <li key={i}>
+            <Link href="#" className="block rounded px-2 py-1 hover:bg-blue-800">
+              {i}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}

--- a/components/SignInModal.tsx
+++ b/components/SignInModal.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+interface Props {
+  onClose: () => void
+}
+
+export default function SignInModal({ onClose }: Props) {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/50">
+      <div className="rounded-2xl bg-white p-8 text-blue-900 shadow">
+        <h2 className="mb-4 text-2xl font-bold">Sign in</h2>
+        <p className="mb-4">Stubbed sign in. Continue in demo mode.</p>
+        <button onClick={onClose} className="rounded bg-gold-500 px-4 py-2 text-blue-900">Demo mode</button>
+      </div>
+    </div>
+  )
+}

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useState } from 'react'
+
+interface Task {
+  name: string
+  days: number
+}
+
+export default function Timeline() {
+  const [tasks, setTasks] = useState<Task[]>([
+    { name: 'Demo', days: 3 },
+    { name: 'Build', days: 5 },
+    { name: 'Finish', days: 2 }
+  ])
+
+  function handleDrag(i: number, e: React.MouseEvent) {
+    const startX = e.clientX
+    const startDays = tasks[i].days
+    function onMove(ev: MouseEvent) {
+      const delta = ev.clientX - startX
+      const newDays = Math.max(1, startDays + Math.round(delta / 20))
+      setTasks(t => t.map((task, idx) => (idx === i ? { ...task, days: newDays } : task)))
+    }
+    function onUp() {
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onUp)
+    }
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onUp)
+  }
+
+  return (
+    <div className="space-y-2">
+      {tasks.map((task, i) => (
+        <div key={task.name} className="flex items-center gap-2">
+          <div className="w-24">{task.name}</div>
+          <div
+            className="h-6 cursor-col-resize rounded bg-gold-500"
+            style={{ width: task.days * 20 }}
+            onMouseDown={e => handleDrag(i, e)}
+          />
+          <span>{task.days}d</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useEffect } from 'react'
+
+interface Props {
+  message: string
+  onDone: () => void
+}
+
+export default function Toast({ message, onDone }: Props) {
+  useEffect(() => {
+    const t = setTimeout(onDone, 3000)
+    return () => clearTimeout(t)
+  }, [onDone])
+  return (
+    <div className="fixed bottom-4 right-4 rounded bg-blue-900 px-4 py-2 text-white shadow">
+      {message}
+    </div>
+  )
+}

--- a/components/Topbar.tsx
+++ b/components/Topbar.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function Topbar() {
+  const [project, setProject] = useState('123 Main St')
+  return (
+    <header className="flex items-center justify-between bg-blue-900 p-4 text-white">
+      <select
+        value={project}
+        onChange={e => setProject(e.target.value)}
+        className="rounded bg-blue-800 p-2"
+      >
+        <option>123 Main St</option>
+        <option>456 Oak Ave</option>
+      </select>
+      <div className="flex items-center gap-2">
+        <span>Demo User</span>
+      </div>
+    </header>
+  )
+}

--- a/components/VendorEmailDraft.tsx
+++ b/components/VendorEmailDraft.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function VendorEmailDraft() {
+  const [text, setText] = useState('Hello vendor, ...')
+  return (
+    <div className="space-y-4 rounded-2xl bg-white p-4 text-blue-900 shadow">
+      <textarea
+        value={text}
+        onChange={e => setText(e.target.value)}
+        className="w-full rounded border p-2"
+        rows={5}
+      />
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => setText('Hello vendor, ...')}
+          className="rounded bg-blue-900 px-4 py-2 text-white"
+        >
+          Regenerate
+        </button>
+        <button
+          type="button"
+          className="rounded bg-gold-500 px-4 py-2 font-semibold text-blue-900"
+        >
+          Send later
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+}
+export default nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "buildwise-ai",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.13",
+    "postcss": "8.4.21",
+    "tailwindcss": "3.2.7",
+    "typescript": "5.0.2",
+    "@types/react": "18.0.28",
+    "@types/node": "18.15.11"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "buildwise-ai",
+  "name": "beamlot",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,19 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        blue: {
+          900: '#0A1F44'
+        },
+        gold: {
+          500: '#C5A500'
+        }
+      }
+    }
+  },
+  plugins: []
+}
+export default config

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- initialize Next.js app structure with Tailwind config
- add landing, pricing, and dashboard pages
- implement analysis form, results view, timeline, and vendor email draft components
- provide placeholder /api/analyze endpoint

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fnode)*
- `npm run dev` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689696f4d5f4832990b92a4661f33961